### PR TITLE
fix(api): correct CheckName request encoding and response field mapping

### DIFF
--- a/api_service.go
+++ b/api_service.go
@@ -2,9 +2,9 @@ package aml
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 type status string
@@ -30,20 +30,20 @@ type DownloadBatchResponse struct {
 }
 
 type CheckNameRequest struct {
-	NonEnglishName *string `json:"NonEnglishName,omitempty"` // 非英文姓名，無資料為空字串
-	EnglishName    *string `json:"EnglishName,omitempty"`    // 英文姓名，無資料為空字串
-	DOB            *string `json:"DOB,omitempty"`            // 生日 (YYYY/MM/DD，如：2017/09/01)，無資料為空字串
-	Nationality    *string `json:"Nationality,omitempty"`    // 國籍，ISO 國家代碼(如臺灣為 TW，美國為 US) ，無資料為空字串
+	NonEnglishName string `json:"NonEnglishName" url:"NonEnglishName"` // 非英文姓名，無資料為空字串
+	EnglishName    string `json:"EnglishName" url:"EnglishName"`       // 英文姓名，無資料為空字串
+	DOB            string `json:"DOB" url:"DOB"`                       // 生日 (YYYY/MM/DD，如：2017/09/01)，無資料為空字串
+	Nationality    string `json:"Nationality" url:"Nationality"`       // 國籍，ISO 國家代碼(如臺灣為 TW，美國為 US) ，無資料為空字串
 }
 
 type rawCheckNameResponse struct {
-	Status status `json:"status"`
-	Error  string `json:"error,omitempty"` // 失敗原因，當 status 為 error 時回傳
+	Status status   `json:"status"`
+	Errors []string `json:"errors,omitempty"` // 失敗原因，當 status 為 error 時回傳
 	CheckNameResponse
 }
 
 type CheckNameResponse struct {
-	RCScore int `json:"RCScore"` // 相似度分數，會回傳RC>=91 或 RC=0，如果上傳結果失敗，回傳-1。
+	RCScore int `json:"rcscore"` // 相似度分數，會回傳RC>=91 或 RC=0，如果上傳結果失敗，回傳-1。
 }
 
 type rawQueryOverResponse struct {
@@ -81,7 +81,7 @@ func (c *Client) DownloadBatch(ctx context.Context, request *DownloadBatchReques
 }
 
 func (c *Client) CheckName(ctx context.Context, request *CheckNameRequest, opts ...RequestOption) (*CheckNameResponse, *Response, error) {
-	req, err := c.NewRequest(ctx, http.MethodPost, "amlupload/api/NameCheck", request, opts)
+	req, err := c.NewFormRequest(ctx, "amlupload/api/NameCheck", request, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +92,7 @@ func (c *Client) CheckName(ctx context.Context, request *CheckNameRequest, opts 
 		return nil, resp, err
 	}
 	if rawResponse.Status == statusError {
-		return nil, resp, errors.New(rawResponse.Error)
+		return nil, resp, fmt.Errorf("check name failed: %s", strings.Join(rawResponse.Errors, "; "))
 	}
 	return &rawResponse.CheckNameResponse, resp, nil
 }

--- a/api_service.go
+++ b/api_service.go
@@ -30,10 +30,10 @@ type DownloadBatchResponse struct {
 }
 
 type CheckNameRequest struct {
-	NonEnglishName string `json:"NonEnglishName" url:"NonEnglishName"` // 非英文姓名，無資料為空字串
-	EnglishName    string `json:"EnglishName" url:"EnglishName"`       // 英文姓名，無資料為空字串
-	DOB            string `json:"DOB" url:"DOB"`                       // 生日 (YYYY/MM/DD，如：2017/09/01)，無資料為空字串
-	Nationality    string `json:"Nationality" url:"Nationality"`       // 國籍，ISO 國家代碼(如臺灣為 TW，美國為 US) ，無資料為空字串
+	NonEnglishName string `url:"NonEnglishName"` // 非英文姓名，無資料為空字串
+	EnglishName    string `url:"EnglishName"`    // 英文姓名，無資料為空字串
+	DOB            string `url:"DOB"`            // 生日 (YYYY/MM/DD，如：2017/09/01)，無資料為空字串
+	Nationality    string `url:"Nationality"`    // 國籍，ISO 國家代碼(如臺灣為 TW，美國為 US) ，無資料為空字串
 }
 
 type rawCheckNameResponse struct {
@@ -81,7 +81,7 @@ func (c *Client) DownloadBatch(ctx context.Context, request *DownloadBatchReques
 }
 
 func (c *Client) CheckName(ctx context.Context, request *CheckNameRequest, opts ...RequestOption) (*CheckNameResponse, *Response, error) {
-	req, err := c.NewFormRequest(ctx, "amlupload/api/NameCheck", request, opts)
+	req, err := c.newFormRequest(ctx, "amlupload/api/NameCheck", request, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -157,6 +157,56 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, data any, 
 	return req, nil
 }
 
+func (c *Client) NewFormRequest(ctx context.Context, path string, data any, opts []RequestOption) (*http.Request, error) {
+	u := *c.baseURL
+	unescaped, err := url.PathUnescape(path)
+	if err != nil {
+		return nil, err
+	}
+
+	u.RawPath = c.baseURL.Path + path
+	u.Path = c.baseURL.Path + unescaped
+
+	reqHeaders := make(http.Header)
+	reqHeaders.Set("Accept", "application/json")
+	reqHeaders.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if c.userAgent != "" {
+		reqHeaders.Set("User-Agent", c.userAgent)
+	}
+
+	q := make(url.Values)
+	rawEncoder := reqRaw{
+		UserID:   c.account,
+		Password: c.password,
+		Target:   data,
+	}
+	if err := rawEncoder.EncodeValues("", &q); err != nil {
+		return nil, err
+	}
+
+	body := strings.NewReader(q.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range reqHeaders {
+		req.Header[k] = v
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(req); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return req, nil
+}
+
 func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -172,5 +222,3 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 
 	return newResponse(resp), err
 }
-
-func par

--- a/client.go
+++ b/client.go
@@ -88,30 +88,54 @@ func (c *Client) setBaseURL(urlStr string) error {
 	return nil
 }
 
-func (c *Client) NewRequest(ctx context.Context, method, path string, data any, opts []RequestOption) (*http.Request, error) { //nolint:lll
+func (c *Client) resolveURL(path string) (url.URL, error) {
 	u := *c.baseURL
 	unescaped, err := url.PathUnescape(path)
+	if err != nil {
+		return url.URL{}, err
+	}
+	u.RawPath = c.baseURL.Path + path
+	u.Path = c.baseURL.Path + unescaped
+	return u, nil
+}
+
+func (c *Client) newHTTPRequest(ctx context.Context, method string, u url.URL, contentType string, body io.Reader, opts []RequestOption) (*http.Request, error) { //nolint:lll
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the encoded path data
-	u.RawPath = c.baseURL.Path + path
-	u.Path = c.baseURL.Path + unescaped
-
-	// Create a request specific headers map.
-	reqHeaders := make(http.Header)
-	reqHeaders.Set("Accept", "application/json")
-
+	req.Header.Set("Accept", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
 	if c.userAgent != "" {
-		reqHeaders.Set("User-Agent", c.userAgent)
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(req); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return req, nil
+}
+
+func (c *Client) NewRequest(ctx context.Context, method, path string, data any, opts []RequestOption) (*http.Request, error) { //nolint:lll
+	u, err := c.resolveURL(path)
+	if err != nil {
+		return nil, err
 	}
 
 	var body io.Reader
+	var contentType string
+
 	switch {
 	case method == http.MethodPatch || method == http.MethodPost || method == http.MethodPut:
-		reqHeaders.Set("Content-Type", "application/json")
-
+		contentType = "application/json"
 		b, err := json.Marshal(reqRaw{
 			UserID:   c.account,
 			Password: c.password,
@@ -135,44 +159,13 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, data any, 
 		u.RawQuery = q.Encode()
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set the request specific headers.
-	for k, v := range reqHeaders {
-		req.Header[k] = v
-	}
-
-	// Apply request options
-	for _, opt := range opts {
-		if opt != nil {
-			if err := opt(req); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return req, nil
+	return c.newHTTPRequest(ctx, method, u, contentType, body, opts)
 }
 
-func (c *Client) NewFormRequest(ctx context.Context, path string, data any, opts []RequestOption) (*http.Request, error) {
-	u := *c.baseURL
-	unescaped, err := url.PathUnescape(path)
+func (c *Client) newFormRequest(ctx context.Context, path string, data any, opts []RequestOption) (*http.Request, error) {
+	u, err := c.resolveURL(path)
 	if err != nil {
 		return nil, err
-	}
-
-	u.RawPath = c.baseURL.Path + path
-	u.Path = c.baseURL.Path + unescaped
-
-	reqHeaders := make(http.Header)
-	reqHeaders.Set("Accept", "application/json")
-	reqHeaders.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if c.userAgent != "" {
-		reqHeaders.Set("User-Agent", c.userAgent)
 	}
 
 	q := make(url.Values)
@@ -185,26 +178,7 @@ func (c *Client) NewFormRequest(ctx context.Context, path string, data any, opts
 		return nil, err
 	}
 
-	body := strings.NewReader(q.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	for k, v := range reqHeaders {
-		req.Header[k] = v
-	}
-
-	for _, opt := range opts {
-		if opt != nil {
-			if err := opt(req); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return req, nil
+	return c.newHTTPRequest(ctx, http.MethodPost, u, "application/x-www-form-urlencoded", strings.NewReader(q.Encode()), opts)
 }
 
 func (c *Client) Do(req *http.Request, v any) (*Response, error) {

--- a/response.go
+++ b/response.go
@@ -38,7 +38,7 @@ type UploadBatchResponseData struct {
 
 // NameCheckResponseData represents the data of a name check response.
 type NameCheckResponseData struct {
-	RCScore int `json:"RCScore"`
+	RCScore int `json:"rcscore"`
 }
 
 // QueryOverResponseData represents the data of a query over response.

--- a/response.go
+++ b/response.go
@@ -36,11 +36,6 @@ type UploadBatchResponseData struct {
 	BatchNo string `json:"batchNo"`
 }
 
-// NameCheckResponseData represents the data of a name check response.
-type NameCheckResponseData struct {
-	RCScore int `json:"rcscore"`
-}
-
 // QueryOverResponseData represents the data of a query over response.
 type QueryOverResponseData struct {
 	Remain int `json:"remain"`


### PR DESCRIPTION
- Use form-urlencoded POST instead of JSON for NameCheck API
- Fix response field name: "error" (string) → "errors" ([]string)
- Fix response field tag: "RCScore" → "rcscore" to match actual API
- Change CheckNameRequest fields from *string to string with url tags
- Add NewFormRequest method to support form-urlencoded POST requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Name check request fields are now required (previously optional).
  * RC score field in API responses is now "rcscore" (lowercase).
  * Error responses may include multiple error messages instead of a single error.
  * Request encoding and content handling for name checks changed, which may affect integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->