### PR TITLE
build!: require Go 1.26 and add Go 1.27 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOLANGCI_LINT = $(GO) tool golangci-lint
 .PHONY: go-mod-tidy
 go-mod-tidy:
 	@echo "go mod tidy in all modules" && \
-		$(GO) mod tidy -compat=1.24.0
+		$(GO) mod tidy -compat=1.26.0
 
 .PHONY: lint
 lint: go-mod-tidy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-aml
 
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.26.0-blue)
+
 Go client for the TDCC AML (Anti-Money Laundering) APIs.
 
 ## Features

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-aml
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/google/go-querystring v1.2.0

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.24.0"
+    "go": "1.26.0"
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
Rotate the Go support window to the two currently supported major versions: require Go 1.26 and treat 1.27 as current.

## Changes
- Raise the module language version from `1.24.0` to `1.26.0`
- Align `go mod tidy -compat` and Renovate `constraints.go` with `1.26.0`
- Document the new minimum in the README badge

## Motivation
- Go 1.27 was released on 2026-08-19; each major version is supported until two newer majors exist
- The supported window is now 1.26 and 1.27, so 1.24 is out of support

## Breaking Changes
- The published module now requires Go 1.26 or later. Builds with Go 1.24 or 1.25 will fail.

## Migration
1. Upgrade the consuming toolchain to Go 1.26 or 1.27
2. Re-run `go get github.com/flc1125/go-aml@<new-tag>` (or `go get` after the release) and tidy as usual

## Behavior and Compatibility
- Public API, request/response encoding, and runtime behavior are unchanged
- This repo has no CI workflows, so there is no test matrix or lint `go-version` to update

## Testing
- `go mod tidy -compat=1.26.0` (go line stays `1.26.0`, no `toolchain`, `go.sum` unchanged)
- `go test ./... -race`
- `go build ./...`
- golangci-lint v2.13.1 (supports Go 1.27) against current `.golangci.yml`; four pre-existing findings, not addressed here. `make lint` still cannot run because golangci-lint is not registered as a `go tool`